### PR TITLE
fix highlight groups not working due to powerline API change

### DIFF
--- a/powerlinemem/mem_usage.py
+++ b/powerlinemem/mem_usage.py
@@ -25,7 +25,7 @@ def mem_usage(pl, format="%s/%s"):
         {
             'contents': format % (_sizeof_fmt(mem_data.used), _sizeof_fmt(mem_data.total)),
             'gradient_level': mem_percentage,
-            'highlight_group': ['mem_usage_gradient', 'mem_usage']
+            'highlight_groups': ['mem_usage_gradient', 'mem_usage']
         }
     ]
 
@@ -36,6 +36,6 @@ def mem_usage_percent(pl, format="%d%%"):
         {
             'contents': format % (mem_percentage, ),
             'gradient_level': mem_percentage,
-            'highlight_group': ['mem_usage_gradient', 'mem_usage']
+            'highlight_groups': ['mem_usage_gradient', 'mem_usage']
         }
     ]


### PR DESCRIPTION
As of the latest version of powerline, this memory segment is still working perfectly. The only problem is the highlight gradient not working due to a powerline API change from _'highlight_group'_ to _'highlight_group**s**'_.
This commit should fix it 🙂
