### PR TITLE
Add short form of size units

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,17 @@ The type of memory to use can be configured by passing the desired [psutil attri
 		}
     }
 
+The short form of size units (i.e. "`K`", "`M`", "`G`"...) can be used by passing the `short` argument (the default is `False`):
+
+
+    {
+        "function": "powerlinemem.mem_usage.mem_usage",
+		"args": {
+		    "short": true
+		}
+    }
+
+
 One or two highlight groups named ```mem_usage``` and ```mem_usage_gradient``` have to be defined in the colorscheme json file. For example:
 
     "mem_usage":                 { "fg": "gray8", "bg": "gray0", "attrs": [] },

--- a/powerlinemem/mem_usage.py
+++ b/powerlinemem/mem_usage.py
@@ -1,21 +1,24 @@
 import psutil
 
-def _sizeof_fmt(num, suffix='B'):
+def _sizeof_fmt(num, short=False, suffix='B'):
     """
     Converts a byte value into a human-readable string.
     Stolen from http://stackoverflow.com/a/1094933/236130
 
     Args:
         num: The byte value
+        short: The short form of units
         suffix: The suffix appended to 'Mi', 'Gi' etc.
 
     Returns a string representation of the bytes.
     """
-    for unit in ['', 'Ki', 'Mi', 'Gi', 'Ti', 'Pi', 'Ei', 'Zi']:
+    if short:
+        suffix = ''
+    for unit in [('', ''), ('Ki', 'K'), ('Mi', 'M'), ('Gi', 'G'), ('Ti', 'T'), ('Pi', 'P'), ('Ei', 'E'), ('Zi', 'Z')]:
         if abs(num) < 1024.0:
-            return "%3.1f%s%s" % (num, unit, suffix)
+            return "%3.1f%s%s" % (num, unit[int(short)], suffix)
         num /= 1024.0
-    return "%.1f%s%s" % (num, 'Yi', suffix)
+    return "%.1f%s%s" % (num, ('Yi', 'Y')[int(short)], suffix)
 
 def _get_mem_used(mem_data, mem_type):
     mem_used = getattr(mem_data, mem_type, None)
@@ -23,13 +26,13 @@ def _get_mem_used(mem_data, mem_type):
         mem_used = mem_data.used
     return mem_used
 
-def mem_usage(pl, format="%s/%s", mem_type='used'):
+def mem_usage(pl, format="%s/%s", mem_type='used', short=False):
     mem_data = psutil.virtual_memory()
     mem_used = _get_mem_used(mem_data, mem_type)
     mem_percentage = (float(mem_used) / mem_data.total) * 100
     return [
         {
-            'contents': format % (_sizeof_fmt(mem_used), _sizeof_fmt(mem_data.total)),
+            'contents': format % (_sizeof_fmt(mem_used, short), _sizeof_fmt(mem_data.total, short)),
             'gradient_level': mem_percentage,
             'highlight_groups': ['mem_usage_gradient', 'mem_usage'],
             'divider_highlight_group': 'background:divider'


### PR DESCRIPTION
It might be useful to use the short form of size units when there's not enough space to display.
So I added an argument `short` to specify whether to use the short form.

If the short form is specified, the size units are displayed as K, M, G instead of KiB, MiB, GiB.