### PR TITLE
Use Powerline Segment class instead of the old Powerline function interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# Intellij IDE stuff
+.idea/

--- a/README.md
+++ b/README.md
@@ -10,30 +10,23 @@ Segment for [Powerline](https://github.com/powerline/powerline) showing the curr
 To apply the segment, add the following to the Powerline configuration file:
 
     {
-        "function": "powerlinemem.mem_usage.mem_usage"
+        "function": "powerlinemem.mem_usage"
     }
 
-For a percentage status, use the ```mem_usage_percent``` callable:
+The percentage status can be configured using the ```format_type``` argument:
 
     {
-        "function": "powerlinemem.mem_usage.mem_usage_percent"
-    }
-
-The format can be configured using the ```format``` argument:
-
-    {
-        "function": "powerlinemem.mem_usage.mem_usage_percent",
-        "priority": 50,
-		"args": {
-		    "format": "Mem: %d%%"
-		}
+        "function": "powerlinemem.mem_usage",
+        "args": {
+            "format_type": "percentage"
+        }
     }
     
 The type of memory to use can be configured by passing the desired [psutil attribute name](https://pythonhosted.org/psutil/#psutil.virtual_memory) as the ``mem_type`` argument (the default is "`used`"):
 
 
     {
-        "function": "powerlinemem.mem_usage.mem_usage",
+        "function": "powerlinemem.mem_usage",
         "priority": 50,
 		"args": {
 		    "mem_type": "active"
@@ -44,7 +37,7 @@ The short form of size units (i.e. "`K`", "`M`", "`G`"...) can be used by passin
 
 
     {
-        "function": "powerlinemem.mem_usage.mem_usage",
+        "function": "powerlinemem.mem_usage",
 		"args": {
 		    "short": true
 		}

--- a/powerlinemem/__init__.py
+++ b/powerlinemem/__init__.py
@@ -1,0 +1,1 @@
+from .mem_usage import mem_usage

--- a/powerlinemem/mem_usage.py
+++ b/powerlinemem/mem_usage.py
@@ -1,4 +1,6 @@
 import psutil
+from powerline import Segment, with_docstring
+
 
 def _sizeof_fmt(num, short=False, suffix='B'):
     """
@@ -20,34 +22,70 @@ def _sizeof_fmt(num, short=False, suffix='B'):
         num /= 1024.0
     return "%.1f%s%s" % (num, ('Yi', 'Y')[int(short)], suffix)
 
-def _get_mem_used(mem_data, mem_type):
-    mem_used = getattr(mem_data, mem_type, None)
-    if mem_used is None:
-        mem_used = mem_data.used
-    return mem_used
 
-def mem_usage(pl, format="%s/%s", mem_type='used', short=False):
-    mem_data = psutil.virtual_memory()
-    mem_used = _get_mem_used(mem_data, mem_type)
-    mem_percentage = (float(mem_used) / mem_data.total) * 100
-    return [
-        {
-            'contents': format % (_sizeof_fmt(mem_used, short), _sizeof_fmt(mem_data.total, short)),
-            'gradient_level': mem_percentage,
-            'highlight_groups': ['mem_usage_gradient', 'mem_usage'],
-            'divider_highlight_group': 'background:divider'
-        }
-    ]
+class MemUsageSegment(Segment):
 
-def mem_usage_percent(pl, format="%d%%", mem_type='used'):
-    mem_data = psutil.virtual_memory()
-    mem_used = _get_mem_used(mem_data, mem_type)
-    mem_percentage = (float(mem_used) / mem_data.total) * 100
-    return [
-        {
-            'contents': format % (mem_percentage, ),
-            'gradient_level': mem_percentage,
-            'highlight_groups': ['mem_usage_gradient', 'mem_usage'],
-            'divider_highlight_group': 'background:divider'
+    def _get_mem_data(self):
+        return psutil.virtual_memory()
+
+    def _get_mem_type(self, mem_data, mem_type):
+        mem_used = getattr(mem_data, mem_type, None)
+        if mem_used is None:
+            mem_used = mem_data.used
+        return mem_used
+
+    def _get_segment(self, content, gradient_level, highlight_groups=None,
+                     divider_highlight_group="background:divider"):
+        if highlight_groups is None:
+            highlight_groups = ['mem_usage_gradient', 'mem_usage']
+        return [
+            {
+                'contents': content,
+                'gradient_level': gradient_level,
+                'highlight_groups': highlight_groups,
+                'divider_highlight_group': divider_highlight_group
+            }
+        ]
+
+    def mem_usage(self, pl, mem_type='used', short=False, fmt='%s/%s'):
+        mem_data = self._get_mem_data()
+        mem_used = self._get_mem_type(mem_data, mem_type)
+        mem_percentage = (float(mem_used) / mem_data.total) * 100
+        return self._get_segment(fmt % (_sizeof_fmt(mem_used, short), _sizeof_fmt(mem_data.total, short)),
+                                 mem_percentage)
+
+    def mem_usage_percent(self, pl, mem_type='used', fmt="%d%%"):
+        mem_data = self._get_mem_data()
+        mem_used = self._get_mem_type(mem_data, mem_type)
+        mem_percentage = (float(mem_used) / mem_data.total) * 100
+        return self._get_segment(fmt % (mem_percentage,), mem_percentage)
+
+    def __call__(self, pl, format_type='used_total', mem_type='used', short=False):
+        mem_usage_function_mapping = {
+            "used_total": self.mem_usage,
+            "percentage": self.mem_usage_percent
         }
-    ]
+        return mem_usage_function_mapping.get(format_type)(pl, mem_type, short)
+
+
+mem_usage = with_docstring(MemUsageSegment(), """
+Return the memory usage of the system.
+
+It can return the memory usage in two ways, either as a fraction in the form of mem_used/mem_total or as a percentage 
+{mem_used}%.
+
+:param str format_type:
+    Mention the format_type to be used to show the memory usage of the system. Currently, only two format types are 
+    supported - `used_total`, `percentage`.
+
+:param str mem_type:
+    Mention the type of memory that is to be evaluated. Valid options are `used`, `active`, `inactive`, `available`, 
+    `buffers`, `cached`, `shared` and `slab`. Default value is `used`. If any invalid value is used, it defaults to 
+    `used`.
+
+:param bool short:
+    Show the MBs, KBs, GBs as M, K, G, etc. A value of `True` shows the short version else shows the default version.
+
+Divider highlight group used: ``background:divider``.
+Highlight groups used: ``mem_usage``, ``mem_usage_gradient``.
+""")


### PR DESCRIPTION
1. Combined the two functions `mem_usage` and `mem_usage_percent` into a single class `MemUsageSegment` and exposed a single object of that class.
2. Added documentation on how the parameters are used.
3. Updated README.md to reflect the new refactored implementation.